### PR TITLE
fix: correctly calculate and show player average rating

### DIFF
--- a/code-challenge/src/App.css
+++ b/code-challenge/src/App.css
@@ -118,3 +118,9 @@ button[type="submit"]:disabled {
   background-color: #f8f9fa;
   border-radius: 4px;
 }
+.average-message {
+  font-weight: bold;
+  color: #2e7d32; /* green tone */
+  margin-top: 1rem;
+}
+

--- a/code-challenge/src/components/MatchRating.js
+++ b/code-challenge/src/components/MatchRating.js
@@ -6,6 +6,9 @@ const MatchRating = ({ players, setPlayers }) => {
   const [rating, setRating] = useState(4.0);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState('');
+  const [updatedAverage, setUpdatedAverage] = useState(null);
+  const [updatedPlayerName, setUpdatedPlayerName] = useState('');
+
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -19,8 +22,35 @@ const MatchRating = ({ players, setPlayers }) => {
     setMessage('Submitting rating...');
     
     try {
-      const updatedPlayers = await submitRating(selectedPlayer, rating, players);
+      const updatedPlayers = players.map(player => {
+        const newPlayer = { ...player };
+      
+        if (newPlayer.id === selectedPlayer) {
+          // Initialize if missing
+          if (newPlayer.numRatings === undefined) {
+            newPlayer.numRatings = 1;
+            newPlayer.totalRating = newPlayer.averageRating;
+          }
+      
+          newPlayer.totalRating += rating;
+          newPlayer.numRatings += 1;
+      
+          newPlayer.averageRating = parseFloat((newPlayer.totalRating / newPlayer.numRatings).toFixed(1));
+        }
+      
+        return newPlayer;
+      });
+      
+    
+      // Submit to mock API (no real processing, just returns what we send)
+      await submitRating(selectedPlayer, rating, updatedPlayers);
+    
+      // Update the players state with locally updated data
       setPlayers(updatedPlayers);
+      const updatedPlayer = updatedPlayers.find(p => p.id === selectedPlayer);
+      setUpdatedAverage(updatedPlayer.averageRating);
+      setUpdatedPlayerName(updatedPlayer.name);
+
       setMessage('Rating submitted successfully!');
     } catch (error) {
       setMessage(`Error: ${error.message}`);
@@ -67,9 +97,14 @@ const MatchRating = ({ players, setPlayers }) => {
         </button>
         
         {message && <p className="message">{message}</p>}
+        {updatedAverage !== null && (
+          <p className="average-message">
+            {updatedPlayerName}’s new average: {updatedAverage}
+          </p>
+        )}
       </form>
     </div>
   );
 };
 
-export default MatchRating; 
+export default MatchRating;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "BYOB-code-challenges",
+  "name": "code-challenges",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
- Fixed bug where first rating replaced average instead of averaging.
- Added totalRating and numRatings to maintain running average.
- Displayed updated average inline on Match Ratings page.


- Added support to **track two new fields per player**:
  - `totalRating` – cumulative sum of all submitted ratings
  - `numRatings` – number of ratings submitted
- Replaced the logic that overwrote the average with this calculation:
