### PR TITLE
Fix: Ensure initial ratings are used & enhance rating submission UX

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/code-challenge.iml
+++ b/.idea/code-challenge.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/code-challenge.iml" filepath="$PROJECT_DIR$/.idea/code-challenge.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/code-challenge/src/App.js
+++ b/code-challenge/src/App.js
@@ -4,20 +4,56 @@ import PlayersList from './components/PlayersList';
 import MatchRating from './components/MatchRating';
 import { fetchPlayers } from './api/playerApi';
 
+
 function App() {
   const [activeTab, setActiveTab] = useState('players');
   const [players, setPlayers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     // Load initial player data
     const loadPlayers = async () => {
-      const loadedPlayers = await fetchPlayers();
-      setPlayers(loadedPlayers);
+      setIsLoading(true);
+      // Added Try and Catch in case there is something wrong with our api calls.
+      try{
+        const loadedPlayers = await fetchPlayers();
+
+        // --- Modified localStorage with initialize values from playerAPI.js---
+        const ratingsStr = localStorage.getItem('ratings');
+        const ratings = ratingsStr ? JSON.parse(ratingsStr) : {}; // Correctly parses
+        let localStorageRatingsModified = false;
+
+        for (const player of loadedPlayers) {
+          const initialRating = player.averageRating;
+
+          if (initialRating !== undefined) {
+            const currentRatingsForPlayer = ratings[player.id];
+            if (!currentRatingsForPlayer || !Array.isArray(currentRatingsForPlayer) || currentRatingsForPlayer.length === 0) {
+              // Seed only if no ratings exist for this player in localStorage['ratings']
+              ratings[player.id] = [initialRating];
+              localStorageRatingsModified = true;
+            }
+          }
+        }
+
+        if (localStorageRatingsModified) {
+          localStorage.setItem('ratings', JSON.stringify(ratings));
+        }
+        // --- Added Changes ---
+
+        setPlayers(loadedPlayers);
+      }catch (e) {
+        console.error(`Failed to load players: ${e}`);
+      }finally {
+        setIsLoading(false);
+      }
     };
-    
+
     loadPlayers();
   }, []);
-
+  if (isLoading){
+    return <div className="app-loading">Loading Players ...</div>;
+  }
   return (
     <div className="App">
       <header className="App-header">

--- a/code-challenge/src/components/MatchRating.js
+++ b/code-challenge/src/components/MatchRating.js
@@ -9,7 +9,10 @@ const MatchRating = ({ players, setPlayers }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
+
+    // Rest a message.
+    setMessage('');
+
     if (!selectedPlayer) {
       setMessage('Please select a player');
       return;
@@ -22,6 +25,12 @@ const MatchRating = ({ players, setPlayers }) => {
       const updatedPlayers = await submitRating(selectedPlayer, rating, players);
       setPlayers(updatedPlayers);
       setMessage('Rating submitted successfully!');
+
+      // Resetting the player and rating to default.
+      // So the User won't keep clicking submitting unintentionally.
+      setSelectedPlayer('');
+      setRating(4.0);
+
     } catch (error) {
       setMessage(`Error: ${error.message}`);
     } finally {


### PR DESCRIPTION
First, to improve the user experience in the MatchRating component, the selected player dropdown and the rating slider are now reset to their default states after a rating is successfully submitted. This prevents accidental re-submissions of the same rating and makes it easier for the user to rate another player.

Second, an issue was identified where the initial 'averageRating' for players (as defined in playerApi.js and loaded into localStorage['players']) was not being accounted for by the calculateAverageRating API when the first match rating was submitted for a player. This was because calculateAverageRating only uses ratings from localStorage['ratings'], which was initialized as empty by playerApi.js.

To address this without modifying the API files (playerApi.js, ratingApi.js), the App.js component was modified. Now, when App.js loads players for the first time (in useEffect):
- It fetches the players.
- It then reads the 'ratings' data from localStorage.
- For each loaded player, if their initial 'averageRating' is defined and no ratings for that specific player are yet present in the 'ratings' localStorage, this 'averageRating' is seeded as the first rating in an array for that player (e.g., {'playerId': [initialAvgRating]}).
- This modified 'ratings' object is then saved back to localStorage. This ensures that the player's initial averageRating is correctly factored into all subsequent average calculations performed by the existing calculateAverageRating API.

From Coding Assistant: Github Copilot for speeding the development, and Gemini searched the following: 
- Checked how the localStorage work. 